### PR TITLE
test: better xfail test for multipart bodies

### DIFF
--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -326,7 +326,7 @@ def test_request_body_multi_part(t_type: Type[Any]):
 def test_request_body_multi_part_mixed_field_content_types() -> None:
     class MultiPartFormWithMixedFields(BaseModel):
         # TODO: define an API for declaring the fields
-        file: UploadFile
+        image: UploadFile
         tags: List[str]
 
     @post(path="/")
@@ -338,8 +338,11 @@ def test_request_body_multi_part_mixed_field_content_types() -> None:
         response = client.post(
             "/",
             files=[
-                ("file", ("somefile.txt", b"file data")),
-                ("tags", (None, b"tags=1&tags=2", "application/x-www-form-urlencoded")),
+                ("image", ("image.png", b"data")),
+            ],
+            data=[
+                ("tags", "1"),
+                ("tags", "2"),
             ],
         )
         assert response.status_code == HTTP_201_CREATED

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -331,7 +331,7 @@ def test_request_body_multi_part_mixed_field_content_types() -> None:
 
     @post(path="/")
     async def test_method(data: MultiPartFormWithMixedFields = Body(media_type=RequestEncodingType.MULTI_PART)) -> None:
-        assert await data.file.read() == b"file data"
+        assert await data.file.read() == b"data"
         assert data.tags == ["1", "2"]
 
     with create_test_client(test_method) as client:


### PR DESCRIPTION
I think this is a better example.
This now represents the pretty common use case of uploading a file and some metadata.
This is describable by OpenAPI.

The Starlette equivalent would be:

```python
from starlette import applications, requests, responses, routing, testclient

def test_request_body_multi_part_mixed_field_content_types_starlette() -> None:
    async def test_method(request: requests.Request) -> responses.Response:
        form = await request.form()
        assert await form["image"].read() == b"data"
        assert [v for k, v in form.multi_items() if k == "tags"] == ["1", "2"]
        return responses.Response(status_code=201)
    
    app = applications.Starlette(routes=[routing.Route("/", test_method, methods=["POST"])])

    with testclient.TestClient(app) as client:
        response = client.post(
            "/",
            files=[ ("image", ("image.png", b"data"))],
            data=[("tags", "1"), ("tags", "2")],
        )
        assert response.status_code == HTTP_201_CREATED
```